### PR TITLE
Add central workflow which requires CORE4 labels on PRs prior to merging

### DIFF
--- a/require-label.yml
+++ b/require-label.yml
@@ -1,0 +1,8 @@
+
+name: Require CORE4 label for PRs prior to merge
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, reopened, edited]
+jobs:
+  require-label:
+    uses: guardian/product-and-engineering-metrics/.github/workflows/require-label.yml@main


### PR DESCRIPTION
This PR adds a workflow that enforces one of the CORE4 labels on PRs prior to merge